### PR TITLE
make provision to allow ssh from a cidr range in case you need it

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,7 @@ module "gcp_hashiqube" {
   ssh_public_key                          = var.ssh_public_key
   ssh_private_key                         = var.ssh_private_key
   debug_user_data                         = var.debug_user_data
+  debug_allow_ssh_cidr_range              = var.debug_allow_ssh_cidr_range
   aws_hashiqube_ip                        = var.deploy_to_aws ? try(module.aws_hashiqube[0].hashiqube_ip, null) : null
   azure_hashiqube_ip                      = var.deploy_to_azure ? try(module.azure_hashiqube[0].hashiqube_ip, null) : null
   my_ipaddress                            = data.external.myipaddress.result.ip
@@ -124,17 +125,18 @@ module "aws_hashiqube" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
   # source = "git::git@github.com:star3am/terraform-hashicorp-hashiqube.git//modules/aws-hashiqube?ref=v0.0.1"
-  source          = "./modules/aws-hashiqube"
-  deploy_to_aws   = var.deploy_to_aws
-  deploy_to_azure = var.deploy_to_azure
-  deploy_to_gcp   = var.deploy_to_gcp
-  ssh_public_key  = var.ssh_public_key
-  ssh_private_key = var.ssh_private_key
-  debug_user_data = var.debug_user_data
-  # aws_credentials      = var.aws_credentials
-  aws_instance_type = var.aws_instance_type
+  source                     = "./modules/aws-hashiqube"
+  deploy_to_aws              = var.deploy_to_aws
+  deploy_to_azure            = var.deploy_to_azure
+  deploy_to_gcp              = var.deploy_to_gcp
+  ssh_public_key             = var.ssh_public_key
+  ssh_private_key            = var.ssh_private_key
+  debug_user_data            = var.debug_user_data
+  debug_allow_ssh_cidr_range = var.debug_allow_ssh_cidr_range
+  aws_region                 = var.aws_region
+  aws_instance_type          = var.aws_instance_type
   # aws_profile          = var.aws_profile
-  aws_region                              = var.aws_region
+  # aws_credentials      = var.aws_credentials
   whitelist_cidr                          = var.whitelist_cidr
   azure_hashiqube_ip                      = var.deploy_to_azure ? try(module.azure_hashiqube[0].hashiqube_ip, null) : null
   gcp_hashiqube_ip                        = var.deploy_to_gcp ? try(module.gcp_hashiqube[0].hashiqube_ip, null) : null
@@ -157,6 +159,7 @@ module "azure_hashiqube" {
   ssh_public_key                          = var.ssh_public_key
   ssh_private_key                         = var.ssh_private_key
   debug_user_data                         = var.debug_user_data
+  debug_allow_ssh_cidr_range              = var.debug_allow_ssh_cidr_range
   aws_hashiqube_ip                        = var.deploy_to_aws ? try(module.aws_hashiqube[0].hashiqube_ip, null) : null
   gcp_hashiqube_ip                        = var.deploy_to_gcp ? try(module.gcp_hashiqube[0].hashiqube_ip, null) : null
   my_ipaddress                            = data.external.myipaddress.result.ip

--- a/modules/aws-hashiqube/README.md
+++ b/modules/aws-hashiqube/README.md
@@ -24,6 +24,7 @@ The following resources are used by this module:
 - [aws_security_group.hashiqube](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) (resource)
 - [aws_security_group_rule.aws_hashiqube](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) (resource)
 - [aws_security_group_rule.azure_hashiqube](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) (resource)
+- [aws_security_group_rule.debug_allow_ssh_cidr_range](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) (resource)
 - [aws_security_group_rule.gcp_hashiqube](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) (resource)
 - [aws_security_group_rule.terraform_cloud_api_ip_ranges](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) (resource)
 - [aws_security_group_rule.terraform_cloud_notifications_ip_ranges](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) (resource)
@@ -63,6 +64,14 @@ Description: Azure Hahiqube IP address
 Type: `string`
 
 Default: `null`
+
+### <a name="input_debug_allow_ssh_cidr_range"></a> [debug_allow_ssh_cidr_range](#input_debug_allow_ssh_cidr_range)
+
+Description: CAREFUL! Debug Open SSH port 22 to this CIDR range, use only in emergency
+
+Type: `string`
+
+Default: `""`
 
 ### <a name="input_debug_user_data"></a> [debug_user_data](#input_debug_user_data)
 

--- a/modules/aws-hashiqube/main.tf
+++ b/modules/aws-hashiqube/main.tf
@@ -144,6 +144,7 @@ resource "aws_security_group" "hashiqube" {
   }
 }
 
+# tfsec:ignore:aws-vpc-disallow-mixed-sgr
 resource "aws_security_group_rule" "terraform_cloud_api_ip_ranges" {
   count             = var.debug_user_data == true ? 1 : 0
   description       = "Allow terraform_cloud_api_ip_ranges"
@@ -155,6 +156,7 @@ resource "aws_security_group_rule" "terraform_cloud_api_ip_ranges" {
   security_group_id = aws_security_group.hashiqube.id
 }
 
+# tfsec:ignore:aws-vpc-disallow-mixed-sgr
 resource "aws_security_group_rule" "terraform_cloud_notifications_ip_ranges" {
   count             = var.debug_user_data == true ? 1 : 0
   description       = "Allow var.terraform_cloud_notifications_ip_ranges"
@@ -208,6 +210,18 @@ resource "aws_security_group_rule" "whitelist_cidr" {
   protocol          = "all"
   cidr_blocks       = [var.whitelist_cidr]
   from_port         = 0
+  security_group_id = aws_security_group.hashiqube.id
+}
+
+# tfsec:ignore:aws-vpc-disallow-mixed-sgr
+resource "aws_security_group_rule" "debug_allow_ssh_cidr_range" {
+  count             = var.debug_allow_ssh_cidr_range != "" ? 1 : 0
+  description       = "Debug Open SSH port 22 to this CIDR range"
+  type              = "ingress"
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = [var.debug_allow_ssh_cidr_range]
+  from_port         = 22
   security_group_id = aws_security_group.hashiqube.id
 }
 

--- a/modules/aws-hashiqube/variables.tf
+++ b/modules/aws-hashiqube/variables.tf
@@ -22,6 +22,12 @@ variable "debug_user_data" {
   description = "Debug Output the User Data of the Cloud instance during Terraform Apply"
 }
 
+variable "debug_allow_ssh_cidr_range" {
+  type        = string
+  default     = ""
+  description = "CAREFUL! Debug Open SSH port 22 to this CIDR range, use only in emergency"
+}
+
 variable "azure_hashiqube_ip" {
   type        = string
   default     = null

--- a/modules/azure-hashiqube/README.md
+++ b/modules/azure-hashiqube/README.md
@@ -18,6 +18,7 @@ The following resources are used by this module:
 - [azurerm_network_interface.hashiqube](https://registry.terraform.io/providers/hashicorp/azurerm/3.57.0/docs/resources/network_interface) (resource)
 - [azurerm_network_security_group.aws_hashiqube_ip](https://registry.terraform.io/providers/hashicorp/azurerm/3.57.0/docs/resources/network_security_group) (resource)
 - [azurerm_network_security_group.azure_hashiqube_ip](https://registry.terraform.io/providers/hashicorp/azurerm/3.57.0/docs/resources/network_security_group) (resource)
+- [azurerm_network_security_group.debug_allow_ssh_cidr_range](https://registry.terraform.io/providers/hashicorp/azurerm/3.57.0/docs/resources/network_security_group) (resource)
 - [azurerm_network_security_group.gcp_hashiqube_ip](https://registry.terraform.io/providers/hashicorp/azurerm/3.57.0/docs/resources/network_security_group) (resource)
 - [azurerm_network_security_group.my_ipaddress](https://registry.terraform.io/providers/hashicorp/azurerm/3.57.0/docs/resources/network_security_group) (resource)
 - [azurerm_network_security_group.terraform_cloud_api_ip_ranges](https://registry.terraform.io/providers/hashicorp/azurerm/3.57.0/docs/resources/network_security_group) (resource)
@@ -61,6 +62,14 @@ Description: The region in which all Azure resources will be launched
 Type: `string`
 
 Default: `"Australia East"`
+
+### <a name="input_debug_allow_ssh_cidr_range"></a> [debug_allow_ssh_cidr_range](#input_debug_allow_ssh_cidr_range)
+
+Description: CAREFUL! Debug Open SSH port 22 to this CIDR range, use only in emergency
+
+Type: `string`
+
+Default: `""`
 
 ### <a name="input_debug_user_data"></a> [debug_user_data](#input_debug_user_data)
 

--- a/modules/azure-hashiqube/main.tf
+++ b/modules/azure-hashiqube/main.tf
@@ -220,6 +220,27 @@ resource "azurerm_network_security_group" "terraform_cloud_notifications_ip_rang
   }
 }
 
+resource "azurerm_network_security_group" "debug_allow_ssh_cidr_range" {
+  count               = var.debug_allow_ssh_cidr_range != "" ? 1 : 0
+  name                = "debug_allow_ssh_cidr_range"
+  location            = var.azure_region
+  resource_group_name = azurerm_resource_group.hashiqube.name
+  security_rule {
+    name                         = "debug_allow_ssh_cidr_range"
+    priority                     = 1008
+    direction                    = "Inbound"
+    access                       = "Allow"
+    protocol                     = "Tcp"
+    source_port_range            = "22"
+    destination_port_range       = "22"
+    source_address_prefixes      = [var.debug_allow_ssh_cidr_range]
+    destination_address_prefixes = [azurerm_network_interface.hashiqube.private_ip_address]
+  }
+  tags = {
+    environment = "hashiqube"
+  }
+}
+
 # Create network interface
 resource "azurerm_network_interface" "hashiqube" {
   name                = "hashiqube"

--- a/modules/azure-hashiqube/variables.tf
+++ b/modules/azure-hashiqube/variables.tf
@@ -22,6 +22,12 @@ variable "debug_user_data" {
   description = "Debug Output the User Data of the Cloud instance during Terraform Apply"
 }
 
+variable "debug_allow_ssh_cidr_range" {
+  type        = string
+  default     = ""
+  description = "CAREFUL! Debug Open SSH port 22 to this CIDR range, use only in emergency"
+}
+
 variable "aws_hashiqube_ip" {
   type        = string
   default     = null

--- a/modules/gcp-hashiqube/README.md
+++ b/modules/gcp-hashiqube/README.md
@@ -17,6 +17,7 @@ The following resources are used by this module:
 - [google_compute_address.hashiqube](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) (resource)
 - [google_compute_firewall.aws_hashiqube_ip](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) (resource)
 - [google_compute_firewall.azure_hashiqube_ip](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) (resource)
+- [google_compute_firewall.debug_allow_ssh_cidr_range](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) (resource)
 - [google_compute_firewall.gcp_hashiqube_ip](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) (resource)
 - [google_compute_firewall.my_ipaddress](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) (resource)
 - [google_compute_firewall.terraform_cloud_api_ip_ranges](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) (resource)
@@ -53,6 +54,14 @@ Description: Azure Hahiqube IP address
 Type: `string`
 
 Default: `null`
+
+### <a name="input_debug_allow_ssh_cidr_range"></a> [debug_allow_ssh_cidr_range](#input_debug_allow_ssh_cidr_range)
+
+Description: CAREFUL! Debug Open SSH port 22 to this CIDR range, use only in emergency
+
+Type: `string`
+
+Default: `""`
 
 ### <a name="input_debug_user_data"></a> [debug_user_data](#input_debug_user_data)
 

--- a/modules/gcp-hashiqube/main.tf
+++ b/modules/gcp-hashiqube/main.tf
@@ -188,6 +188,18 @@ resource "google_compute_firewall" "whitelist_cidr" {
   source_ranges = [var.whitelist_cidr]
 }
 
+resource "google_compute_firewall" "debug_allow_ssh_cidr_range" {
+  count   = var.debug_allow_ssh_cidr_range != "" ? 1 : 0
+  name    = "debug-allow-ssh-cidr-range"
+  network = "default"
+  project = var.gcp_project
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+  source_ranges = [var.debug_allow_ssh_cidr_range]
+}
+
 resource "google_compute_firewall" "terraform_cloud_api_ip_ranges" {
   count   = var.debug_user_data == true ? 1 : 0
   name    = "terraform-cloud-api-ip-ranges"

--- a/modules/gcp-hashiqube/variables.tf
+++ b/modules/gcp-hashiqube/variables.tf
@@ -22,6 +22,12 @@ variable "debug_user_data" {
   description = "Debug Output the User Data of the Cloud instance during Terraform Apply"
 }
 
+variable "debug_allow_ssh_cidr_range" {
+  type        = string
+  default     = ""
+  description = "CAREFUL! Debug Open SSH port 22 to this CIDR range, use only in emergency"
+}
+
 variable "aws_hashiqube_ip" {
   type        = string
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "debug_user_data" {
   description = "Debug Output the User Data of the Cloud instance during Terraform Apply"
 }
 
+variable "debug_allow_ssh_cidr_range" {
+  type        = string
+  default     = ""
+  description = "CAREFUL! Debug Open SSH port 22 to this CIDR range, use only in emergency"
+}
+
 # You can find the full list of provisioners in the Vagrantfile
 variable "vagrant_provisioners" {
   description = "The list of services you would like to run in Hashiqube, the more you run, the bigger instance youd need with more RAM"


### PR DESCRIPTION
create a way to open SSH to a CIDR port in case you need it, such as build agents from an unknown CIDR range